### PR TITLE
서비스 뷰 dto 재설계 및 초기화면 설정

### DIFF
--- a/src/main/java/com/example/projectfuture/controller/MainController.java
+++ b/src/main/java/com/example/projectfuture/controller/MainController.java
@@ -8,9 +8,6 @@ public class MainController {
 
     @GetMapping("/")
     public String root() {
-        return "redirect:/articles";
+        return "forward:/articles";
     }
-
-
-
 }

--- a/src/main/java/com/example/projectfuture/dto/ArticleCommentDto.java
+++ b/src/main/java/com/example/projectfuture/dto/ArticleCommentDto.java
@@ -1,15 +1,41 @@
 package com.example.projectfuture.dto;
 
+import com.example.projectfuture.domain.Article;
+import com.example.projectfuture.domain.ArticleComment;
 import java.time.LocalDateTime;
 
 public record ArticleCommentDto(
+        Long id,
+        Long articleId,
+        UserAccountDto userAccountDto,
+        String content,
         LocalDateTime createdAt,
         String createdBy,
         LocalDateTime modifiedAt,
-        String modifiedBy,
-        String content
+        String modifiedBy
 ) {
-    public static ArticleCommentDto of(LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy, String content) {
-        return new ArticleCommentDto(createdAt, createdBy, modifiedAt, modifiedBy, content);
+    public static ArticleCommentDto of (Long id, Long articleId, UserAccountDto userAccountDto, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleCommentDto(id, articleId, userAccountDto, content, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static ArticleCommentDto from(ArticleComment entity) {
+        return new ArticleCommentDto(
+                entity.getId(),
+                entity.getArticle().getId(),
+                UserAccountDto.from(entity.getUserAccount()),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public ArticleComment toEntity(Article entity) {
+        return ArticleComment.of(
+                entity,
+                userAccountDto.toEntity(),
+                content
+        );
     }
 }

--- a/src/main/java/com/example/projectfuture/dto/ArticleDto.java
+++ b/src/main/java/com/example/projectfuture/dto/ArticleDto.java
@@ -1,16 +1,44 @@
 package com.example.projectfuture.dto;
 
-import java.io.Serializable;
+import com.example.projectfuture.domain.Article;
+
 import java.time.LocalDateTime;
 
 public record ArticleDto(
-        LocalDateTime createdAt,
-        String createdBy,
+        Long id,
+        UserAccountDto userAccountDto,
         String title,
         String content,
-        String hashtag
+        String hashtag,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
 ) {
-    public static ArticleDto of(LocalDateTime createdAt, String createdBy, String title, String content, String hashtag) {
-        return new ArticleDto(createdAt, createdBy, title, content, hashtag);
+    public static ArticleDto of (Long id, UserAccountDto userAccountDto, String title, String content, String hashtag, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleDto(id, userAccountDto, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static ArticleDto from(Article entity) {
+        return new ArticleDto(
+                entity.getId(),
+                UserAccountDto.from(entity.getUserAccount()),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getHashtag(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+    public Article toEntity() {
+        return Article.of(
+                userAccountDto.toEntity(),
+                title,
+                content,
+                hashtag
+        );
     }
 }

--- a/src/main/java/com/example/projectfuture/dto/ArticleWithCommentsDto.java
+++ b/src/main/java/com/example/projectfuture/dto/ArticleWithCommentsDto.java
@@ -1,0 +1,42 @@
+package com.example.projectfuture.dto;
+
+import com.example.projectfuture.domain.Article;
+
+import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ArticleWithCommentsDto(
+        Long id,
+        UserAccountDto userAccountDto,
+        Set<ArticleCommentDto> articleCommentDtoSet,
+        String title,
+        String content,
+        String hashtag,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static ArticleWithCommentsDto of(Long id, UserAccountDto userAccountDto, Set<ArticleCommentDto> articleCommentDtoSet, String title, String content, String hashtag, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleWithCommentsDto(id, userAccountDto, articleCommentDtoSet, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static ArticleWithCommentsDto from(Article entity) {
+        return new ArticleWithCommentsDto(
+                entity.getId(),
+                UserAccountDto.from(entity.getUserAccount()),
+                entity.getArticleComment().stream()
+                        .map(ArticleCommentDto::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                entity.getTitle(),
+                entity.getContent(),
+                entity.getHashtag(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+}

--- a/src/main/java/com/example/projectfuture/dto/UserAccountDto.java
+++ b/src/main/java/com/example/projectfuture/dto/UserAccountDto.java
@@ -1,0 +1,45 @@
+package com.example.projectfuture.dto;
+
+import com.example.projectfuture.domain.UserAccount;
+import java.time.LocalDateTime;
+
+public record UserAccountDto(
+        Long id,
+        String userId,
+        String userPassword,
+        String email,
+        String nickname,
+        String memo,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static UserAccountDto of(Long id, String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(id, userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+
+    public static UserAccountDto from(UserAccount entity) {
+        return new UserAccountDto(
+                entity.getId(),
+                entity.getUserId(),
+                entity.getUserPassword(),
+                entity.getEmail(),
+                entity.getNickname(),
+                entity.getMemo(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+    public UserAccount toEntity() {
+        return UserAccount.of(
+                userId,
+                userPassword,
+                email,
+                nickname,
+                memo
+        );
+    }
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
 </head>
 <body>
-
+<!-- 루트 패쓰는 게시판으로 redirect 되는 형식으로 변경- TODO : 나중에 생각해서 다시 사용하거나 삭제하는 방향으로 검토 -->
 </body>
 </html>

--- a/src/test/java/com/example/projectfuture/controller/MainControllerTest.java
+++ b/src/test/java/com/example/projectfuture/controller/MainControllerTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -25,7 +26,9 @@ class MainControllerTest {
     @Test
     void givenNothing_whenRequestingRootPage_thenRedirectsToArticlesPage() throws Exception {
         mvc.perform(get("/"))
-                .andExpect(status().is3xxRedirection());
+                .andExpect(status().isOk())
+                .andExpect(view().name("forward:/articles"))
+                .andExpect(forwardedUrl("/articles"))
+                .andDo(MockMvcResultHandlers.print());
     }
-
 }


### PR DESCRIPTION
유저의 정보가 게시글의 내용에 포함되도록 dto를 재설계
초기화면을 게시글 목록으로 들어가게끔 변경

TODO :: 아직 테스트를 하지 않아 수정이 필수적임